### PR TITLE
Fix: updated operator logic in pcap_base_detector.py

### DIFF
--- a/diane/src/crash_detector/pcap_base_detector.py
+++ b/diane/src/crash_detector/pcap_base_detector.py
@@ -114,6 +114,7 @@ class PcapBasedDetector(DefaultCrashDetector):
         for _, curr_d in recv_pkts:
             received_data_size += len(curr_d)
 
+        # fix >= to <=
         if self.normal_transmit_data_size > 0:
             transmit_bammed_up = (transmit_data_size / float(self.normal_transmit_data_size)) <= ANOMALY_THRESHOLD
         else:

--- a/diane/src/crash_detector/pcap_base_detector.py
+++ b/diane/src/crash_detector/pcap_base_detector.py
@@ -115,12 +115,12 @@ class PcapBasedDetector(DefaultCrashDetector):
             received_data_size += len(curr_d)
 
         if self.normal_transmit_data_size > 0:
-            transmit_bammed_up = (transmit_data_size / float(self.normal_transmit_data_size)) >= ANOMALY_THRESHOLD
+            transmit_bammed_up = (transmit_data_size / float(self.normal_transmit_data_size)) <= ANOMALY_THRESHOLD
         else:
             transmit_bammed_up = transmit_data_size > 0
 
         if self.normal_receive_data_size > 0:
-            receive_bammed_up = (received_data_size / float(self.normal_receive_data_size)) >= ANOMALY_THRESHOLD
+            receive_bammed_up = (received_data_size / float(self.normal_receive_data_size)) <= ANOMALY_THRESHOLD
         else:
             receive_bammed_up = received_data_size > 0
 


### PR DESCRIPTION
### Bug Fix: Incorrect anomaly threshold comparison in `verify_size()`

This PR fixes a logical inconsistency between the DIANE paper [Section: Identifying Crashes] and the current implementation.

#### Problem
The code currently uses `>= ANOMALY_THRESHOLD` to detect anomalies based on traffic size, which contradicts the paper’s description that anomalies are indicated when traffic size **falls below** 50% of a normal run.

#### Fix
Replaced `>=` with `<=` so that inputs causing traffic size drop below the threshold are correctly identified as crash-inducing.

#### Reference
**DIANE paper**, Section *"Irregular network traffic size"*:
> "... when the amount of exchanged data was less than 50% (compared to a regular run), something unusual happened to the device."
